### PR TITLE
Add Binder badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Design by [Isabela Presedo-Floyd](https://github.com/isabela-pf), coded with the help of Jovyans at [Quansight](https://github.com/quansight)
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Quansight-Labs/jupyterlab-theme-winter/main?urlpath=lab)
+
 ![](./winter.png)
 
 ## Use


### PR DESCRIPTION
Since `repo2docker` supports configuration via the `setup.py`, it works out of the box quite nicely:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Quansight-Labs/jupyterlab-theme-winter/main?urlpath=lab)

![image](https://user-images.githubusercontent.com/591645/103026192-a4895d80-4553-11eb-80a3-d0daf56e3761.png)


